### PR TITLE
Changes to speed up the simulations

### DIFF
--- a/runs/run_dynamics.jl
+++ b/runs/run_dynamics.jl
@@ -41,7 +41,7 @@ Threads.@threads for i in 1:navg
                bfield(N, Δt, J, noise),
                bfield(N, Δt, J, noise)];
     sol = diffeqsolver(s0, tspan, J, bfields, matrix; saveat=saveat);
-    sols[i, :, :] = sol[2]
+    sols[i, :, :] = transpose(sol[:, :])
     next!(progress)
 end
 

--- a/runs/run_dynamics_ho.jl
+++ b/runs/run_dynamics_ho.jl
@@ -41,8 +41,8 @@ Threads.@threads for i in 1:navg
                bfield(N, Δt, J, noise),
                bfield(N, Δt, J, noise)];
     sol = diffeqsolver(x0, p0, tspan, J, bfields, matrix; saveat=saveat);
-    solx[i, :, :] = sol[2]
-    solp[i, :, :] = sol[3]
+    solx[i, :, :] = transpose(sol[1:3, :])
+    solp[i, :, :] = transpose(sol[4:6, :])
     next!(progress)
 end
 

--- a/runs/run_steadystate.jl
+++ b/runs/run_steadystate.jl
@@ -43,7 +43,7 @@ for n in eachindex(T)
                    bfield(N, Δt, J, noise),
                    bfield(N, Δt, J, noise)];
         sol = diffeqsolver(s0, tspan, J, bfields, matrix; saveat=saveat);
-        s[i, :] = mean(sol[2], dims=1)
+        s[i, :] = mean(sol, dims=2)
     end
     Sss[n, :] = mean(s, dims=1)
     next!(progress)

--- a/runs/run_steadystate_ho.jl
+++ b/runs/run_steadystate_ho.jl
@@ -44,8 +44,8 @@ for n in eachindex(T)
                    bfield(N, Δt, J, noise),
                    bfield(N, Δt, J, noise)];
         sol = diffeqsolver(x0, p0, tspan, J, bfields, matrix; saveat=saveat);
-        x[i, :] = mean(sol[2].^2, dims=1)
-        p[i, :] = mean(sol[3].^2, dims=1)
+        x[i, :] = mean(sol[1:3, :].^2, dims=2)
+        p[i, :] = mean(sol[4:6, :].^2, dims=2)
     end
     xss[n, :] = mean(x, dims=1)
     pss[n, :] = mean(p, dims=1)

--- a/src/Dynamics.jl
+++ b/src/Dynamics.jl
@@ -28,12 +28,13 @@ function diffeqsolver(s0, tspan, J::LorentzianSD, bfields, matrix::Coupling; JH=
     Cω2 = matrix.C*transpose(matrix.C)
     bn = t -> matrix.C*[bfields[1](t), bfields[2](t), bfields[3](t)];
     Cω2v = zeros(3)
+    Beff = zeros(3)
     
     function f(du, u, par, t)
         s = @view u[1:3*N] # @view does not allocate values. No hard copy, just reference.
         v = @view u[1+3*N:3+3*N]
         w = @view u[4+3*N:6+3*N]
-        Beff = Bext + bn(t) + mul!(Cω2v, Cω2, v)
+        Beff .= Bext + bn(t) + mul!(Cω2v, Cω2, v)
         for i in 1:N
             du[1+(i-1)*3:3+(i-1)*3] = -cross(s[1+(i-1)*3:3+(i-1)*3], Beff + sum([JH[i,j] * s[(1+(j-1)*3):(3+(j-1)*3)] for j in 1:N]))
         end
@@ -72,13 +73,14 @@ function diffeqsolver(x0, p0, tspan, J::LorentzianSD, bfields, matrix::Coupling;
     Cω2 = matrix.C*transpose(matrix.C)
     bn = t -> matrix.C*[bfields[1](t), bfields[2](t), bfields[3](t)];
     Cω2v = zeros(3)
+    Beff = zeros(3)
     
     function f(du, u, par, t)
         x = @view u[1:3] # @view does not allocate values. No hard copy, just reference.
         p = @view u[4:6]
         v = @view u[7:9]
         w = @view u[10:12]
-        Beff = bn(t) + mul!(Cω2v, Cω2, v)
+        Beff .= bn(t) + mul!(Cω2v, Cω2, v)
         du[1:3] = p
         du[4:6] = -(Ω^2)*x + Beff
         du[7:9] = w

--- a/src/Dynamics.jl
+++ b/src/Dynamics.jl
@@ -40,15 +40,8 @@ function diffeqsolver(s0, tspan, J::LorentzianSD, bfields, matrix::Coupling; JH=
 
     end
     prob = ODEProblem(f, u0, tspan)
-    sol = solve(prob, Vern7(), abstol=1e-8, reltol=1e-8, maxiters=Int(1e7), saveat=saveat)
-
-    s = zeros(length(sol.t), 3*N)
-    for n in 1:length(sol.t)
-        s[n, :] = sol.u[n][1:3*N]
-    end
-    sinterp = t -> sol(t)[1:3*N]
-    
-    return sol.t, s, sinterp
+    sol = solve(prob, Vern7(), abstol=1e-8, reltol=1e-8, maxiters=Int(1e7), save_idxs=1:3*N, saveat=saveat)
+    return sol
 end
 
 """
@@ -101,5 +94,4 @@ function diffeqsolver(x0, p0, tspan, J::LorentzianSD, bfields, matrix::Coupling;
     pinterp = t -> sol(t)[4:6]
     
     return sol.t, x, p, xinterp, pinterp
-
 end

--- a/src/Dynamics.jl
+++ b/src/Dynamics.jl
@@ -85,16 +85,6 @@ function diffeqsolver(x0, p0, tspan, J::LorentzianSD, bfields, matrix::Coupling;
         du[10:12] = -(J.ω0^2)*v -J.Γ*w + J.α*x
     end
     prob = ODEProblem(f, u0, tspan)
-    sol = solve(prob, Vern7(), abstol=1e-8, reltol=1e-8, maxiters=Int(1e7), saveat=saveat)
-
-    x = zeros(length(sol.t), 3)
-    p = zeros(length(sol.t), 3)
-    for n in 1:length(sol.t)
-        x[n, :] = sol.u[n][1:3]
-        p[n, :] = sol.u[n][4:6]
-    end
-    xinterp = t -> sol(t)[1:3]
-    pinterp = t -> sol(t)[4:6]
-    
-    return sol.t, x, p, xinterp, pinterp
+    sol = solve(prob, Vern7(), abstol=1e-8, reltol=1e-8, maxiters=Int(1e7), save_idxs=1:6, saveat=saveat)
+    return sol
 end


### PR DESCRIPTION
This pull request introduces changes to speed up the simulations.

The main (and breaking) change is that now the `diffeqsolver` family of methods return directly the solution from the DifferentialEquations.jl library, instead of manipulating the result. This surpassingly results in a major speed-up, frequently of 2x or more. However, care should be taken since this change is breaking, mainly since now the order of the time and spin components indices are swapped in the results returned by `diffeqsolver`. Furthermore, the way to access the interpolator is now also different. The example code in the `run` folder has been updated to work with the new conventions, but users of previous versions should change their custom scripts.

There are also some other minor changes, such as pre-allocating some variables repeatedly used in the differential equation to minimise the number of allocations when solving the ODE.