### PR TITLE
Fix behaviour of PSD at zero frequency

### DIFF
--- a/src/Noise.jl
+++ b/src/Noise.jl
@@ -105,4 +105,8 @@ function psd(J::AbstractSD, noise::Noise)
     return psd
 end
 
-psd(J::LorentzianSD, noise::ClassicalNoise) = ω -> 2*J.α*J.Γ*noise.T/((J.ω0^2 - ω^2)^2 + (J.Γ*ω)^2)
+psd(J::LorentzianSD, noise::ClassicalNoise) = ω -> 2*noise.T*π*sdoverω(J, ω)
+
+psd(J::LorentzianSD, noise::QuantumNoise) = ω -> iszero(ω) ? 2*noise.T*π*sdoverω(J, 0) : π*sd(J, ω)*coth(ω/2/noise.T)
+
+psd(J::LorentzianSD, noise::NoZeroQuantumNoise) = ω -> iszero(ω) ? 2*noise.T*π*sdoverω(J, 0) : π*sd(J, ω)*(coth(ω/2/noise.T) - sign(ω))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,7 +106,7 @@ using Test
             sol = diffeqsolver(s0, tspan, J, bfields, Cw; S0=1, saveat=saveat, alg=Vern7(), atol=1e-8, rtol=1e-8);
             sdynss = mean(Array(sol), dims=2)
 
-            @test isapprox(sdynss[:,end], [-0.535859, -0.109671, 0.814815], atol=1e-5)
+            @test isapprox(sdynss[:,end], [-0.535249, -0.133732, 0.811530], atol=1e-5)
         end
     
         @testset "Classical single spin steady state" begin


### PR DESCRIPTION
Taking the ω->0  limit of the PSD should give a non-vanishing contribution at ω=0 , which was not previously included as the noise was forced to zero at ω=0.
